### PR TITLE
Refactor with Defensive Patterns

### DIFF
--- a/lib/companies.js
+++ b/lib/companies.js
@@ -28,27 +28,27 @@ class Companies {
    * @private
    */
   _wrap (method) {
-    if (!Util.canUseIntercom()) {
-      return Promise.resolve()
-    }
+    return Promise.resolve()
+      .then(() => {
+        if (!Util.canUseIntercom()) {
+          return
+        }
 
-    if (!this.client) {
-      return Promise.reject(
-        new Error('Companies._wrap: invalid companies client')
-      )
-    }
+        if (!this.client) {
+          throw new Error('Companies._wrap: invalid companies client')
+        }
 
-    const clientMethod = this.client[method]
-    if (!isFunction(clientMethod)) {
-      return Promise.reject(
-        new Error(`Companies._wrap: companies has no method '${method}'`)
-      )
-    }
+        const clientMethod = this.client[method]
+        if (!isFunction(clientMethod)) {
+          throw new Error(`Companies._wrap: companies has no method '${method}'`)
+        }
 
-    return clientMethod.apply(
-      clientMethod,
-      Array.prototype.slice.call(arguments, 1)
-    )
+        return clientMethod.apply(
+          clientMethod,
+          // NOTE: The first argument is the method name, so we skip it here
+          Array.prototype.slice.call(arguments, 1)
+        )
+      })
   }
 
   /**

--- a/lib/companies.js
+++ b/lib/companies.js
@@ -1,6 +1,8 @@
 'use strict'
 
+const isFunction = require('101/is-function')
 const Promise = require('bluebird')
+const Util = require('./util')
 
 /**
  * Companies - Used for communication with intercomClient's company object
@@ -8,39 +10,55 @@ const Promise = require('bluebird')
  * @author Ryan Kahn
  */
 class Companies {
-
   /**
    * Constructor for Companies
-   * @param {Orion} orion - Instance of Orion which is used for the intercom client and canUseIntercom methods
+   * @param {object} client Intercom client for customer related actions.
    */
-  constructor (orion) {
-    this.orion = orion
+  constructor (client) {
+    this.client = client
   }
 
   /**
-   * Helper method to wrap all the intercomClient.companies calls around canUseIntercom
-   * @param {String} method
-   * @returns {Promise} - Returns success if intercom is disabled,
-   * otherwise returns results of call to intercom client
+   * Helper method to wrap all the intercomClient.companies calls around
+   * `canUseIntercom`
+   * @param {String} method Name of the method to wrap for the intercom
+   *   companies client.
+   * @returns {Promise} - Returns success if intercom is disabled, otherwise
+   *   returns results of call to intercom client
    * @private
    */
   _wrap (method) {
-    if (!this.orion.canUseIntercom()) {
+    if (!Util.canUseIntercom()) {
       return Promise.resolve()
     }
-    var args = Array.prototype.slice.call(arguments)
-    args.shift()
-    return this.orion.intercomClient.companies[method].apply(this.orion.intercomClient.companies, args)
+
+    if (!this.client) {
+      return Promise.reject(
+        new Error('Companies._wrap: invalid companies client')
+      )
+    }
+
+    const clientMethod = this.client[method]
+    if (!isFunction(clientMethod)) {
+      return Promise.reject(
+        new Error(`Companies._wrap: companies has no method '${method}'`)
+      )
+    }
+
+    return clientMethod.apply(
+      clientMethod,
+      Array.prototype.slice.call(arguments, 1)
+    )
   }
 
   /**
    * Upsert a company object, passes data through to intercom
-   * Possible parameters: https://developers.intercom.io/reference#create-or-update-company
    * @param {Object} companyParams
    * @param {Object} companyParams.company_id - Company unique identifier
    * @param {Object} companyParams.name - Company name
-   * @returns {Promise} - Returns success if intercom is disabled,
-   * otherwise returns results of create command in intercom
+   * @returns {Promise} - Returns success if intercom is disabled, otherwise
+   *   returns results of create command in intercom
+   * @see https://developers.intercom.io/reference#create-or-update-company
    */
   create (companyParams) {
     return this._wrap('create', companyParams)
@@ -48,10 +66,10 @@ class Companies {
 
   /**
    * List companies by a tag or segment
-   * Possible parameters: https://developers.intercom.io/reference#list-by-tag-or-segment
    * @param {Object} query
    * @returns {Promise<Array>} - Returns success if intercom is disabled,
-   * otherwise returns list of companies
+   *   otherwise returns list of companies
+   * @see https://developers.intercom.io/reference#list-by-tag-or-segment
    */
   listBy (query) {
     return this._wrap('listBy', query)
@@ -61,7 +79,7 @@ class Companies {
   /**
    * List all companies
    * @returns {Promise<Array>} - Returns success if intercom is disabled,
-   * otherwise returns list of companies
+   *   otherwise returns list of companies
    */
   list () {
     return this._wrap('list')
@@ -72,12 +90,10 @@ class Companies {
    * List all the users who belong to a particular company
    * @param {String} companyId - ID of the company we are listing users for
    * @returns {Promise<Array>} - Returns success if intercom is disabled,
-   * otherwise returns list of users
+   *   otherwise returns list of users
    */
   listUsers (companyId) {
-    return this._wrap('listUsers', {
-      id: companyId
-    })
+    return this._wrap('listUsers', { id: companyId })
       .get('body')
   }
 }

--- a/lib/orion.js
+++ b/lib/orion.js
@@ -1,12 +1,14 @@
 'use strict'
 
-const Intercom = require('intercom-client')
-const exists = require('101/exists')
 const Companies = require('./companies')
+const Intercom = require('intercom-client')
+const keypather = require('keypather')()
+const Util = require('./util')
 
 /**
  * Orion, the huntsman, in charge of helping us hunt down those big customers.
- * Used for communication with intercom with very little mucking about configuration
+ * Used for communication with intercom with very little mucking about
+ * configuration.
  * @class
  * @author Ryan Kahn
  */
@@ -15,17 +17,18 @@ class Orion {
    * Creates a new Orion instance for reporting to intercom
    */
   constructor () {
-    this.companies = new Companies(this)
-    if (!this.canUseIntercom()) { return }
-    this.intercomClient = new Intercom.Client(process.env.INTERCOM_APP_ID, process.env.INTERCOM_API_KEY).usePromises()
-  }
+    // Initialize intercom client
+    if (Util.canUseIntercom()) {
+      this.intercomClient = new Intercom.Client(
+        process.env.INTERCOM_APP_ID,
+        process.env.INTERCOM_API_KEY
+      ).usePromises()
+    }
 
-  /**
-   * Determines if we can use intercom
-   * @returns {boolean}
-   */
-  canUseIntercom () {
-    return exists(process.env.INTERCOM_APP_ID) && exists(process.env.INTERCOM_API_KEY)
+    // Initiaize specific promisifed client adapters
+    this.companies = new Companies(
+      keypather.get(this, 'intercomClient.companies')
+    )
   }
 }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const exists = require('101/exists')
+
+/**
+ * Utility methods used by the orion intercom module.
+ * @class
+ * @author Ryan Sandor Richards
+ */
+class Util {
+  /**
+   * Determines if we can use intercom
+   * @returns {boolean}
+   */
+  static canUseIntercom () {
+    return (
+      exists(process.env.INTERCOM_APP_ID) &&
+      exists(process.env.INTERCOM_API_KEY)
+    )
+  }
+}
+
+module.exports = Util

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "101": "^1.5.0",
     "bluebird": "^3.3.5",
-    "intercom-client": "^2.8.0"
+    "intercom-client": "^2.8.0",
+    "keypather": "^2.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.7.7",
@@ -14,7 +15,6 @@
     "code": "^2.2.1",
     "jsdoc": "^3.4.0",
     "lab": "^10.3.2",
-    "proxyquire": "^1.7.4",
     "sinon": "^1.17.3",
     "standard": "^6.0.8"
   },

--- a/test/mocks/mockIntercom.js
+++ b/test/mocks/mockIntercom.js
@@ -3,5 +3,5 @@
 const sinon = require('sinon')
 
 module.exports = {
-  usePromises: sinon.stub()
+  usePromises: sinon.stub().returns(true)
 }

--- a/test/orion.js
+++ b/test/orion.js
@@ -4,105 +4,63 @@ const Lab = require('lab')
 const lab = exports.lab = Lab.script()
 const describe = lab.describe
 const it = lab.test
-const sinon = require('sinon')
 const beforeEach = lab.beforeEach
 const afterEach = lab.afterEach
-const after = lab.after
+
 const expect = require('code').expect
+const sinon = require('sinon')
+
 const Intercom = require('intercom-client')
 const mockIntercom = require('./mocks/mockIntercom')
-const proxyquire = require('proxyquire')
+
+const Companies = require('../lib/companies')
+const Orion = require('../lib/orion')
+const Util = require('../lib/util')
 
 describe('orion', () => {
-  let Orion
   beforeEach((done) => {
     sinon.stub(Intercom, 'Client').returns(mockIntercom)
-    Orion = proxyquire('../lib/orion', {
-      './companies': sinon.stub()
-    })
+    sinon.stub(Util, 'canUseIntercom')
     done()
   })
 
   afterEach((done) => {
     Intercom.Client.restore()
+    Util.canUseIntercom.restore()
     done()
   })
+
   describe('constructor', () => {
-    const fakeAppId = 'fake app id'
-    const fakeAppKey = 'fake app key'
-    beforeEach((done) => {
-      process.env.INTERCOM_APP_ID = fakeAppId
-      process.env.INTERCOM_API_KEY = fakeAppKey
-      sinon.stub(Orion.prototype, 'canUseIntercom').returns(true)
-      done()
-    })
-
-    afterEach((done) => {
-      Orion.prototype.canUseIntercom.restore()
-      done()
-    })
-
-    it('should check if we can use intercom before creating an intercom client', (done) => {
-      const orion = new Orion()
-      sinon.assert.calledOnce(Orion.prototype.canUseIntercom)
-      sinon.assert.calledOnce(mockIntercom.usePromises)
-      sinon.assert.calledOnce(Intercom.Client)
-      sinon.assert.calledWith(Intercom.Client, fakeAppId, fakeAppKey)
-      expect(orion).to.be.instanceOf(Orion)
-      done()
-    })
-  })
-
-  describe('canUseIntercom', () => {
-    const oldIntercomAPIKey = process.env.INTERCOM_API_KEY
-    const oldIntercomAppId = process.env.INTERCOM_APP_ID
-    let existsStub
-    let orion
-
-    beforeEach((done) => {
-      process.env.INTERCOM_API_KEY = 'fake api key'
-      process.env.INTERCOM_APP_ID = 'fake app id'
-      existsStub = sinon.stub().returns(false)
-      const Orion = proxyquire('../lib/orion', {
-        '101/exists': existsStub
+    describe('with intercom available', () => {
+      beforeEach((done) => {
+        Util.canUseIntercom.returns(true)
+        done()
       })
-      orion = new Orion()
-      existsStub.reset()
-      done()
-    })
 
-    after((done) => {
-      process.env.INTERCOM_API_KEY = oldIntercomAPIKey
-      process.env.INTERCOM_APP_ID = oldIntercomAppId
-      done()
-    })
+      it('should create an intercom client', (done) => {
+        const orion = new Orion()
+        expect(orion.intercomClient).to.exist()
+        done()
+      })
+    }) // end 'with intercom available'
 
-    it('should return false if no INTERCOM_APP_ID', (done) => {
-      delete process.env.INTERCOM_API_KEY
-      existsStub.withArgs(process.env.INTERCOM_API_KEY).returns(false)
-      existsStub.withArgs(process.env.INTERCOM_APP_ID).returns(true)
-      expect(orion.canUseIntercom()).to.equal(false)
-      sinon.assert.calledWith(existsStub, process.env.INTERCOM_API_KEY)
-      done()
-    })
+    describe('without intercom available', () => {
+      beforeEach((done) => {
+        Util.canUseIntercom.returns(false)
+        done()
+      })
 
-    it('should return false if no INTERCOM_APP_ID', (done) => {
-      delete process.env.INTERCOM_APP_ID
-      existsStub.withArgs(process.env.INTERCOM_API_KEY).returns(true)
-      existsStub.withArgs(process.env.INTERCOM_APP_ID).returns(false)
-      expect(orion.canUseIntercom()).to.equal(false)
-      sinon.assert.calledWith(existsStub, process.env.INTERCOM_APP_ID)
-      done()
-    })
+      it('should not create an intercom client', (done) => {
+        const orion = new Orion()
+        expect(orion.intercomClient).to.not.exist()
+        done()
+      })
+    }) // end 'without intercom available'
 
-    it('should return true if everything is set properly', (done) => {
-      existsStub.withArgs(process.env.INTERCOM_API_KEY).returns(true)
-      existsStub.withArgs(process.env.INTERCOM_APP_ID).returns(true)
-      expect(orion.canUseIntercom()).to.equal(true)
-      sinon.assert.calledTwice(existsStub)
-      sinon.assert.calledWith(existsStub, process.env.INTERCOM_API_KEY)
-      sinon.assert.calledWith(existsStub, process.env.INTERCOM_APP_ID)
+    it('should expose the companies client', (done) => {
+      const orion = new Orion()
+      expect(orion.companies).to.be.an.instanceof(Companies)
       done()
     })
-  })
-})
+  }) // end 'constructor'
+}) // end 'orion'

--- a/test/util.js
+++ b/test/util.js
@@ -1,0 +1,45 @@
+const Lab = require('lab')
+const lab = exports.lab = Lab.script()
+const afterEach = lab.afterEach
+const beforeEach = lab.beforeEach
+const describe = lab.describe
+const it = lab.test
+const expect = require('code').expect
+
+const Util = require('../lib/util')
+
+describe('util', () => {
+  describe('canUseIntercom', () => {
+    const oldIntercomAPIKey = process.env.INTERCOM_API_KEY
+    const oldIntercomAppId = process.env.INTERCOM_APP_ID
+
+    beforeEach((done) => {
+      process.env.INTERCOM_API_KEY = 'fake api key'
+      process.env.INTERCOM_APP_ID = 'fake app id'
+      done()
+    })
+
+    afterEach((done) => {
+      process.env.INTERCOM_API_KEY = oldIntercomAPIKey
+      process.env.INTERCOM_APP_ID = oldIntercomAppId
+      done()
+    })
+
+    it('should return false if no INTERCOM_APP_ID', (done) => {
+      delete process.env.INTERCOM_API_KEY
+      expect(Util.canUseIntercom()).to.be.false()
+      done()
+    })
+
+    it('should return false if no INTERCOM_APP_ID', (done) => {
+      delete process.env.INTERCOM_APP_ID
+      expect(Util.canUseIntercom()).to.be.false()
+      done()
+    })
+
+    it('should return true if everything is set properly', (done) => {
+      expect(Util.canUseIntercom()).to.equal(true)
+      done()
+    })
+  }) // end 'canUseIntercom'
+}) // end 'util'


### PR DESCRIPTION
- Companies delegate now uses companies intercom client instead of full orion base class
- Moved `canUseIntercom` out into a utility library
- Added defensive programming in `_wrap` method to avoid unexpected throws
- Refactored and simplified tests
## Reviewers
- [x] @podviaznikov 
- [x] @Myztiq 
