### PR TITLE
Base Class Refactor + Paging Support

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -39,8 +39,8 @@ class Base {
 
         const clientMethod = this.client[method]
         if (!isFunction(clientMethod)) {
-          throw new Error(`
-            Base._wrap: ${this.name} client has no method '${method}'`
+          throw new Error(
+            `Base._wrap: ${this.name} client has no method '${method}'`
           )
         }
 

--- a/lib/base.js
+++ b/lib/base.js
@@ -1,0 +1,84 @@
+'use strict'
+
+const isFunction = require('101/is-function')
+const keypather = require('keypather')()
+const Promise = require('bluebird')
+
+const Util = require('./util')
+
+/**
+ * Base class to wrap intercom client.
+ * @class
+ */
+class Base {
+  /**
+   * Constructor for Base
+   * @param {Object} client Intercom client.
+   */
+  constructor (client, name) {
+    this.baseClient = client
+    this.client = keypather.get(client, name)
+    this.name = name
+  }
+
+  /**
+   * Helper method to wrap all client methods.
+   * @param {String} method Name of the method to wrap.
+   * @returns {Promise} Returns success if intercom is disabled, otherwise
+   *   returns results of call to intercom client.
+   * @private
+   */
+  _wrap (method) {
+    return Promise.resolve()
+      .then(() => {
+        if (!Util.canUseIntercom()) { return }
+
+        if (!this.client) {
+          throw new Error(`Base._wrap: invalid ${this.name} client`)
+        }
+
+        const clientMethod = this.client[method]
+        if (!isFunction(clientMethod)) {
+          throw new Error(`
+            Base._wrap: ${this.name} client has no method '${method}'`
+          )
+        }
+
+        return clientMethod.apply(
+          this.client,
+          // NOTE: The first argument is the method name, so we skip it here
+          Array.prototype.slice.call(arguments, 1)
+        )
+      })
+  }
+
+  /**
+   * Get next page from a previous call.
+   * @private
+   * @param {Object} pageInfo Pages information from a previous call.
+   * @returns {Promise} Returns success if intercom is disabled, otherwise
+   *   returns results of call to intercom client.
+   */
+  nextPage (pageInfo) {
+    return Promise.resolve()
+      .then(() => {
+        if (!Util.canUseIntercom()) { return }
+
+        if (!this.client) {
+          throw new Error(`Base._wrap: invalid ${this.name} client`)
+        }
+
+        return this.baseClient.nextPage(pageInfo).get('body')
+      })
+  }
+
+  /**
+   * List Objects. This is pretty universal.
+   * @return {Promise} Resolves with the body of the list call for the type.
+   */
+  list () {
+    return this._wrap('list').get('body')
+  }
+}
+
+module.exports = Base

--- a/lib/base.js
+++ b/lib/base.js
@@ -53,26 +53,6 @@ class Base {
   }
 
   /**
-   * Get next page from a previous call.
-   * @private
-   * @param {Object} pageInfo Pages information from a previous call.
-   * @returns {Promise} Returns success if intercom is disabled, otherwise
-   *   returns results of call to intercom client.
-   */
-  nextPage (pageInfo) {
-    return Promise.resolve()
-      .then(() => {
-        if (!Util.canUseIntercom()) { return }
-
-        if (!this.client) {
-          throw new Error(`Base._wrap: invalid ${this.name} client`)
-        }
-
-        return this.baseClient.nextPage(pageInfo).get('body')
-      })
-  }
-
-  /**
    * List Objects. This is pretty universal.
    * @return {Promise} Resolves with the body of the list call for the type.
    */

--- a/lib/companies.js
+++ b/lib/companies.js
@@ -1,56 +1,13 @@
 'use strict'
 
-const isFunction = require('101/is-function')
-const Promise = require('bluebird')
-const Util = require('./util')
+const Base = require('./base')
 
 /**
  * Companies - Used for communication with intercomClient's company object
  * @class
  * @author Ryan Kahn
  */
-class Companies {
-  /**
-   * Constructor for Companies
-   * @param {object} client Intercom client for customer related actions.
-   */
-  constructor (client) {
-    this.client = client
-  }
-
-  /**
-   * Helper method to wrap all the intercomClient.companies calls around
-   * `canUseIntercom`
-   * @param {String} method Name of the method to wrap for the intercom
-   *   companies client.
-   * @returns {Promise} - Returns success if intercom is disabled, otherwise
-   *   returns results of call to intercom client
-   * @private
-   */
-  _wrap (method) {
-    return Promise.resolve()
-      .then(() => {
-        if (!Util.canUseIntercom()) {
-          return
-        }
-
-        if (!this.client) {
-          throw new Error('Companies._wrap: invalid companies client')
-        }
-
-        const clientMethod = this.client[method]
-        if (!isFunction(clientMethod)) {
-          throw new Error(`Companies._wrap: companies has no method '${method}'`)
-        }
-
-        return clientMethod.apply(
-          this.client,
-          // NOTE: The first argument is the method name, so we skip it here
-          Array.prototype.slice.call(arguments, 1)
-        )
-      })
-  }
-
+class Companies extends Base {
   /**
    * Upsert a company object, passes data through to intercom
    * @param {Object} companyParams
@@ -73,16 +30,6 @@ class Companies {
    */
   listBy (query) {
     return this._wrap('listBy', query)
-      .get('body')
-  }
-
-  /**
-   * List all companies
-   * @returns {Promise<Array>} - Returns success if intercom is disabled,
-   *   otherwise returns list of companies
-   */
-  list () {
-    return this._wrap('list')
       .get('body')
   }
 

--- a/lib/orion.js
+++ b/lib/orion.js
@@ -47,16 +47,15 @@ class Orion {
    *   returns results of call to intercom client.
    */
   nextPage (pageInfo) {
-    return Promise.resolve()
-      .then(() => {
-        if (!Util.canUseIntercom()) { return }
+    return Promise.try(() => {
+      if (!Util.canUseIntercom()) { return }
 
-        if (!this.intercomClient) {
-          throw new Error('Orion.nextPage: invalid intercom client')
-        }
+      if (!this.intercomClient) {
+        throw new Error('Orion.nextPage: invalid intercom client')
+      }
 
-        return this.intercomClient.nextPage(pageInfo).get('body')
-      })
+      return this.intercomClient.nextPage(pageInfo).get('body')
+    })
   }
 }
 

--- a/lib/orion.js
+++ b/lib/orion.js
@@ -2,7 +2,6 @@
 
 const Companies = require('./companies')
 const Intercom = require('intercom-client')
-const keypather = require('keypather')()
 const Tags = require('./tags')
 const Users = require('./users')
 const Util = require('./util')
@@ -27,16 +26,16 @@ class Orion {
       ).usePromises()
     }
 
-    // Initiaize specific promisifed client adapters
-    this.companies = new Companies(
-      keypather.get(this, 'intercomClient.companies')
-    )
-    this.users = new Users(
-      keypather.get(this, 'intercomClient.users')
-    )
-    this.tags = new Tags(
-      keypather.get(this, 'intercomClient.tags')
-    )
+    const classes = {
+      companies: Companies,
+      tags: Tags,
+      users: Users
+    }
+
+    Object.keys(classes).forEach((name) => {
+      const ClassName = classes[name]
+      this[name] = new ClassName(this.intercomClient, name)
+    })
   }
 }
 

--- a/lib/orion.js
+++ b/lib/orion.js
@@ -2,6 +2,7 @@
 
 const Companies = require('./companies')
 const Intercom = require('intercom-client')
+const Promise = require('bluebird')
 const Tags = require('./tags')
 const Users = require('./users')
 const Util = require('./util')
@@ -36,6 +37,26 @@ class Orion {
       const ClassName = classes[name]
       this[name] = new ClassName(this.intercomClient, name)
     })
+  }
+
+  /**
+   * To maintain compatibility with Intercom's client, this nextPage function
+   * can be used for pagination on any type.
+   * @return {Object} pageInfo Pagination information from a previous request.
+   * @returns {Promise} Returns success if intercom is disabled, otherwise
+   *   returns results of call to intercom client.
+   */
+  nextPage (pageInfo) {
+    return Promise.resolve()
+      .then(() => {
+        if (!Util.canUseIntercom()) { return }
+
+        if (!this.intercomClient) {
+          throw new Error('Orion.nextPage: invalid intercom client')
+        }
+
+        return this.intercomClient.nextPage(pageInfo).get('body')
+      })
   }
 }
 

--- a/lib/orion.js
+++ b/lib/orion.js
@@ -42,6 +42,7 @@ class Orion {
   /**
    * To maintain compatibility with Intercom's client, this nextPage function
    * can be used for pagination on any type.
+   * @see https://github.com/intercom/intercom-node#pagination
    * @return {Object} pageInfo Pagination information from a previous request.
    * @returns {Promise} Returns success if intercom is disabled, otherwise
    *   returns results of call to intercom client.

--- a/lib/tags.js
+++ b/lib/tags.js
@@ -1,64 +1,11 @@
 'use strict'
 
-const isFunction = require('101/is-function')
-const Promise = require('bluebird')
-const Util = require('./util')
+const Base = require('./base')
 
 /**
  * Tags - Used for communication with intercomClient's tags objects
  * @class
  */
-class Tags {
-  /**
-   * Constructor for Tags
-   * @param {object} client Intercom client for tag related actions.
-   */
-  constructor (client) {
-    this.client = client
-  }
-
-  /**
-   * Helper method to wrap all the intercomClient.tags calls around
-   * `canUseIntercom`
-   * @param {String} method Name of the method to wrap for the intercom
-   *   users client.
-   * @returns {Promise} - Returns success if intercom is disabled, otherwise
-   *   returns results of call to intercom client
-   * @private
-   */
-  _wrap (method) {
-    return Promise.resolve()
-      .then(() => {
-        if (!Util.canUseIntercom()) {
-          return
-        }
-
-        if (!this.client) {
-          throw new Error('Tags._wrap: invalid users client')
-        }
-
-        const clientMethod = this.client[method]
-        if (!isFunction(clientMethod)) {
-          throw new Error(`Tags._wrap: users has no method '${method}'`)
-        }
-
-        return clientMethod.apply(
-          this.client,
-          // NOTE: The first argument is the method name, so we skip it here
-          Array.prototype.slice.call(arguments, 1)
-        )
-      })
-  }
-
-  /**
-   * List tags.
-   * @return {Promise} Resolves with list of tags of form:
-   *   { "type": "tag", "id": "375750", "name": "bryantest" }
-   */
-  list () {
-    return this._wrap('list')
-      .get('body')
-  }
-}
+class Tags extends Base {}
 
 module.exports = Tags

--- a/lib/users.js
+++ b/lib/users.js
@@ -1,56 +1,13 @@
 'use strict'
 
-const isFunction = require('101/is-function')
-const Promise = require('bluebird')
-const Util = require('./util')
+const Base = require('./base')
 
 /**
  * Users - Used for communication with intercomClient's user object
  * @class
  * @author Ryan Kahn
  */
-class Users {
-  /**
-   * Constructor for Users
-   * @param {object} client Intercom client for customer related actions.
-   */
-  constructor (client) {
-    this.client = client
-  }
-
-  /**
-   * Helper method to wrap all the intercomClient.users calls around
-   * `canUseIntercom`
-   * @param {String} method Name of the method to wrap for the intercom
-   *   users client.
-   * @returns {Promise} - Returns success if intercom is disabled, otherwise
-   *   returns results of call to intercom client
-   * @private
-   */
-  _wrap (method) {
-    return Promise.resolve()
-      .then(() => {
-        if (!Util.canUseIntercom()) {
-          return
-        }
-
-        if (!this.client) {
-          throw new Error('Users._wrap: invalid users client')
-        }
-
-        const clientMethod = this.client[method]
-        if (!isFunction(clientMethod)) {
-          throw new Error(`Users._wrap: users has no method '${method}'`)
-        }
-
-        return clientMethod.apply(
-          this.client,
-          // NOTE: The first argument is the method name, so we skip it here
-          Array.prototype.slice.call(arguments, 1)
-        )
-      })
-  }
-
+class Users extends Base {
   /**
    * Upsert a user object, passes data through to intercom
    * @param {Object} userParams

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runnable/orion",
-  "version": "1.2.1",
+  "version": "1.3.0-0",
   "description": "Orion, the huntstman, in charge of tracking down big game, in this case big customers.",
   "main": "index.js",
   "dependencies": {

--- a/test/base.js
+++ b/test/base.js
@@ -15,17 +15,13 @@ const Util = require('../lib/util')
 
 describe('Base', function () {
   let base
-  let client
-  const sampleNextPageInfo = { body: { page: 2 } }
 
   beforeEach((done) => {
-    client = {
-      nextPage: sinon.stub().returns(Promise.resolve(sampleNextPageInfo)),
+    base = new Base({
       sample: {
         list: sinon.stub().returns(Promise.resolve(true))
       }
-    }
-    base = new Base(client, 'sample')
+    }, 'sample')
     sinon.stub(Util, 'canUseIntercom').returns(true)
     done()
   })
@@ -69,49 +65,6 @@ describe('Base', function () {
           sinon.assert.calledOnce(Util.canUseIntercom)
           sinon.assert.calledOnce(base.client.list)
           sinon.assert.calledWithExactly(base.client.list)
-        })
-        .asCallback(done)
-    })
-  })
-
-  describe('nextPage', () => {
-    const samplePageInfo = { page: 1 }
-
-    it('should do nothing if we cannot use intercom', (done) => {
-      Util.canUseIntercom.returns(false)
-      base.nextPage(samplePageInfo)
-        .then(() => {
-          sinon.assert.calledOnce(Util.canUseIntercom)
-          sinon.assert.notCalled(base.client.list)
-        })
-        .asCallback(done)
-    })
-
-    it('should reject if the client is invalid', (done) => {
-      base.client = null
-      base.nextPage(samplePageInfo).asCallback((err) => {
-        expect(err).to.exist()
-        expect(err.message).to.match(/invalid.*client/i)
-        done()
-      })
-    })
-
-    it('should call nextPage on the client', (done) => {
-      base.nextPage(samplePageInfo)
-        .then(() => {
-          sinon.assert.calledOnce(base.baseClient.nextPage)
-          sinon.assert.calledWithExactly(
-            base.baseClient.nextPage,
-            samplePageInfo
-          )
-        })
-        .asCallback(done)
-    })
-
-    it('should call nextPage on the client', (done) => {
-      base.nextPage(samplePageInfo)
-        .then((body) => {
-          expect(body).to.equal(sampleNextPageInfo.body)
         })
         .asCallback(done)
     })

--- a/test/base.js
+++ b/test/base.js
@@ -1,0 +1,119 @@
+'use strict'
+
+const Lab = require('lab')
+const lab = exports.lab = Lab.script()
+const describe = lab.describe
+const it = lab.test
+const sinon = require('sinon')
+const beforeEach = lab.beforeEach
+const afterEach = lab.afterEach
+const expect = require('code').expect
+const Promise = require('bluebird')
+
+const Base = require('../lib/base')
+const Util = require('../lib/util')
+
+describe('Base', function () {
+  let base
+  let client
+  const sampleNextPageInfo = { body: { page: 2 } }
+
+  beforeEach((done) => {
+    client = {
+      nextPage: sinon.stub().returns(Promise.resolve(sampleNextPageInfo)),
+      sample: {
+        list: sinon.stub().returns(Promise.resolve(true))
+      }
+    }
+    base = new Base(client, 'sample')
+    sinon.stub(Util, 'canUseIntercom').returns(true)
+    done()
+  })
+
+  afterEach((done) => {
+    Util.canUseIntercom.restore()
+    done()
+  })
+
+  describe('_wrap', () => {
+    it('should do nothing if we cannot use intercom', (done) => {
+      Util.canUseIntercom.returns(false)
+      base._wrap('list')
+        .then(() => {
+          sinon.assert.calledOnce(Util.canUseIntercom)
+          sinon.assert.notCalled(base.client.list)
+        })
+        .asCallback(done)
+    })
+
+    it('should reject if the client is invalid', (done) => {
+      base.client = null
+      base._wrap('list').asCallback((err) => {
+        expect(err).to.exist()
+        expect(err.message).to.match(/invalid.*client/i)
+        done()
+      })
+    })
+
+    it('should reject if the method does not exist', (done) => {
+      base._wrap('not-a-thing').asCallback((err) => {
+        expect(err).to.exist()
+        expect(err.message).to.match(/has no method/i)
+        done()
+      })
+    })
+
+    it('should call method on client with supplied arguments', (done) => {
+      base._wrap('list')
+        .then(() => {
+          sinon.assert.calledOnce(Util.canUseIntercom)
+          sinon.assert.calledOnce(base.client.list)
+          sinon.assert.calledWithExactly(base.client.list)
+        })
+        .asCallback(done)
+    })
+  })
+
+  describe('nextPage', () => {
+    const samplePageInfo = { page: 1 }
+
+    it('should do nothing if we cannot use intercom', (done) => {
+      Util.canUseIntercom.returns(false)
+      base.nextPage(samplePageInfo)
+        .then(() => {
+          sinon.assert.calledOnce(Util.canUseIntercom)
+          sinon.assert.notCalled(base.client.list)
+        })
+        .asCallback(done)
+    })
+
+    it('should reject if the client is invalid', (done) => {
+      base.client = null
+      base.nextPage(samplePageInfo).asCallback((err) => {
+        expect(err).to.exist()
+        expect(err.message).to.match(/invalid.*client/i)
+        done()
+      })
+    })
+
+    it('should call nextPage on the client', (done) => {
+      base.nextPage(samplePageInfo)
+        .then(() => {
+          sinon.assert.calledOnce(base.baseClient.nextPage)
+          sinon.assert.calledWithExactly(
+            base.baseClient.nextPage,
+            samplePageInfo
+          )
+        })
+        .asCallback(done)
+    })
+
+    it('should call nextPage on the client', (done) => {
+      base.nextPage(samplePageInfo)
+        .then((body) => {
+          expect(body).to.equal(sampleNextPageInfo.body)
+        })
+        .asCallback(done)
+    })
+  })
+})

--- a/test/companies.js
+++ b/test/companies.js
@@ -18,7 +18,9 @@ describe('Companies', function () {
 
   beforeEach((done) => {
     company = new Companies({
-      create: sinon.stub().returns(Promise.resolve('create'))
+      companies: {
+        create: sinon.stub().returns(Promise.resolve('create'))
+      }
     })
     sinon.stub(Util, 'canUseIntercom').returns(true)
     done()
@@ -27,45 +29,6 @@ describe('Companies', function () {
   afterEach((done) => {
     Util.canUseIntercom.restore()
     done()
-  })
-
-  describe('_wrap', () => {
-    it('should do nothing if we cannot use intercom', (done) => {
-      Util.canUseIntercom.returns(false)
-      company._wrap('create', '1', '2', '3')
-        .then(() => {
-          sinon.assert.calledOnce(Util.canUseIntercom)
-          sinon.assert.notCalled(company.client.create)
-        })
-        .asCallback(done)
-    })
-
-    it('should reject if the client is invalid', (done) => {
-      company.client = null
-      company._wrap('create').asCallback((err) => {
-        expect(err).to.exist()
-        expect(err.message).to.match(/invalid.*client/i)
-        done()
-      })
-    })
-
-    it('should reject if the method does not exist', (done) => {
-      company._wrap('not-a-thing').asCallback((err) => {
-        expect(err).to.exist()
-        expect(err.message).to.match(/has no method/i)
-        done()
-      })
-    })
-
-    it('should call method on client with supplied arguments', (done) => {
-      company._wrap('create', '1', '2', '3')
-        .then(() => {
-          sinon.assert.calledOnce(Util.canUseIntercom)
-          sinon.assert.calledOnce(company.client.create)
-          sinon.assert.calledWith(company.client.create, '1', '2', '3')
-        })
-        .asCallback(done)
-    })
   })
 
   describe('create', () => {

--- a/test/tags.js
+++ b/test/tags.js
@@ -6,93 +6,26 @@ const describe = lab.describe
 const it = lab.test
 const sinon = require('sinon')
 const beforeEach = lab.beforeEach
-const afterEach = lab.afterEach
 const expect = require('code').expect
 const Promise = require('bluebird')
 
+const Base = require('../lib/base')
 const Tags = require('../lib/tags')
-const Util = require('../lib/util')
 
-describe('Tags', function () {
+describe('Tags', () => {
   let tag
 
   beforeEach((done) => {
     tag = new Tags({
-      list: sinon.stub().returns(Promise.resolve('list'))
-    })
-    sinon.stub(Util, 'canUseIntercom').returns(true)
-    done()
-  })
-
-  afterEach((done) => {
-    Util.canUseIntercom.restore()
-    done()
-  })
-
-  describe('_wrap', () => {
-    it('should do nothing if we cannot use intercom', (done) => {
-      Util.canUseIntercom.returns(false)
-      tag._wrap('list')
-        .then(() => {
-          sinon.assert.calledOnce(Util.canUseIntercom)
-          sinon.assert.notCalled(tag.client.list)
-        })
-        .asCallback(done)
-    })
-
-    it('should reject if the client is invalid', (done) => {
-      tag.client = null
-      tag._wrap('list').asCallback((err) => {
-        expect(err).to.exist()
-        expect(err.message).to.match(/invalid.*client/i)
-        done()
-      })
-    })
-
-    it('should reject if the method does not exist', (done) => {
-      tag._wrap('not-a-thing').asCallback((err) => {
-        expect(err).to.exist()
-        expect(err.message).to.match(/has no method/i)
-        done()
-      })
-    })
-
-    it('should call method on client with supplied arguments', (done) => {
-      tag._wrap('list')
-        .then(() => {
-          sinon.assert.calledOnce(Util.canUseIntercom)
-          sinon.assert.calledOnce(tag.client.list)
-          sinon.assert.calledWithExactly(tag.client.list)
-        })
-        .asCallback(done)
-    })
-  })
-
-  describe('list', () => {
-    const returnedVal = {
-      body: {
-        foo: 'bar'
+      tags: {
+        list: sinon.stub().returns(Promise.resolve('list'))
       }
-    }
-
-    beforeEach((done) => {
-      sinon.stub(tag, '_wrap').returns(Promise.resolve(returnedVal))
-      done()
     })
+    done()
+  })
 
-    afterEach((done) => {
-      tag._wrap.restore()
-      done()
-    })
-
-    it('should call _wrap with the proper parameters', (done) => {
-      tag.list()
-        .then((results) => {
-          sinon.assert.calledOnce(tag._wrap)
-          sinon.assert.calledWithExactly(tag._wrap, 'list')
-          expect(results).to.equal(returnedVal.body)
-        })
-        .asCallback(done)
-    })
+  it('should extend base', (done) => {
+    expect(tag).to.be.an.instanceOf(Base)
+    done()
   })
 })

--- a/test/users.js
+++ b/test/users.js
@@ -10,62 +10,24 @@ const afterEach = lab.afterEach
 const expect = require('code').expect
 const Promise = require('bluebird')
 
+const Base = require('../lib/base')
 const Users = require('../lib/users')
-const Util = require('../lib/util')
 
 describe('Users', function () {
   let user
 
   beforeEach((done) => {
     user = new Users({
-      create: sinon.stub().returns(Promise.resolve('create'))
+      users: {
+        create: sinon.stub().returns(Promise.resolve('create'))
+      }
     })
-    sinon.stub(Util, 'canUseIntercom').returns(true)
     done()
   })
 
-  afterEach((done) => {
-    Util.canUseIntercom.restore()
+  it('should extend base', (done) => {
+    expect(user).to.be.an.instanceOf(Base)
     done()
-  })
-
-  describe('_wrap', () => {
-    it('should do nothing if we cannot use intercom', (done) => {
-      Util.canUseIntercom.returns(false)
-      user._wrap('create', '1', '2', '3')
-        .then(() => {
-          sinon.assert.calledOnce(Util.canUseIntercom)
-          sinon.assert.notCalled(user.client.create)
-        })
-        .asCallback(done)
-    })
-
-    it('should reject if the client is invalid', (done) => {
-      user.client = null
-      user._wrap('create').asCallback((err) => {
-        expect(err).to.exist()
-        expect(err.message).to.match(/invalid.*client/i)
-        done()
-      })
-    })
-
-    it('should reject if the method does not exist', (done) => {
-      user._wrap('not-a-thing').asCallback((err) => {
-        expect(err).to.exist()
-        expect(err.message).to.match(/has no method/i)
-        done()
-      })
-    })
-
-    it('should call method on client with supplied arguments', (done) => {
-      user._wrap('create', '1', '2', '3')
-        .then(() => {
-          sinon.assert.calledOnce(Util.canUseIntercom)
-          sinon.assert.calledOnce(user.client.create)
-          sinon.assert.calledWith(user.client.create, '1', '2', '3')
-        })
-        .asCallback(done)
-    })
   })
 
   describe('create', () => {


### PR DESCRIPTION
'big' change that didn't really change all that much. I added a method to the Orion class called `nextPage` that calls the base client w/ the next page info (as described in intercom's documentation). Should be a good match.
#### Reviewers
- [x] @thejsj
