### PR TITLE
Remove testing environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 node_js:
-  - "4.2"
   - "4"
-  - "5"
   - "6"
 sudo: false
 script:


### PR DESCRIPTION
Having `4` and `4.2` is a little redundant. `5` was unstable and `6` is the new `lts`, so we should just drop `5`.
